### PR TITLE
docs(README): set the appropriate lua version for path generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ busted spec/path_to_file.lua
 If you see a `module 'busted.runner'` not found error you need to update your `LUA_PATH`:
 
 ```bash
-eval $(luarocks path --no-bin)
+eval $(luarocks path --no-bin --lua-version 5.1)
 busted --lua nlua spec/mytest_spec.lua
 ```
 


### PR DESCRIPTION
If the default version is left unspecified for the `luarocks path` invocation then luarocks will produce paths that will not help the error message in any way. In other places luarocks will likely function without explicitly specifying a version flag.