### PR TITLE
feat: add `luarocks_args` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,12 @@ that can't be installed automatically using `luarocks test`.
 
 ### luarocks_args (optional)
 
-Arguments to pass to `luarocks`.
+Arguments to pass to `luarocks`.  E.g., to run only tests which match `some_test`:
+
+```yaml
+  with:
+    luarocks_args: '-- --filter some_test'
+```
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ A bash script to run before running the tests.
 For example, you can use this to install additional luarocks packages
 that can't be installed automatically using `luarocks test`.
 
+### luarocks_args (optional)
+
+Arguments to pass to `luarocks`.
+
 ## Resources
 
 - [`nvim-lua/nvim-lua-plugin-template`](https://github.com/nvim-lua/nvim-lua-plugin-template/)

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
   luarocks_args:
     description: Arguments for LuaRocks
     required: false
-    default: '[]'
+    default: ''
     type: string
 runs:
   using: "composite"
@@ -78,5 +78,5 @@ runs:
         luarocks install nlua --local
       shell: bash
 
-    - run: luarocks test --local ${{ join(fromJSON(inputs.luarocks_args), ' ') }}
+    - run: luarocks test --local ${{ inputs.luarocks_args }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,8 @@ inputs:
   luarocks_args:
     description: Arguments for LuaRocks
     required: false
-    default: ''
+    default: '[]'
+    type: string
 runs:
   using: "composite"
   steps:
@@ -77,5 +78,5 @@ runs:
         luarocks install nlua --local
       shell: bash
 
-    - run: luarocks test --local ${{ inputs.luarocks_args }}
+    - run: luarocks test --local ${{ join(fromJSON(inputs.luarocks_args), ' ') }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: Script to run before running tests.
     required: false
     default: ''
+  luarocks_args:
+    description: Arguments for LuaRocks
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -73,5 +77,5 @@ runs:
         luarocks install nlua --local
       shell: bash
 
-    - run: luarocks test --local
+    - run: luarocks test --local ${{ inputs.luarocks_args }}
       shell: bash


### PR DESCRIPTION
My particular use case is that we have a repo with a neovim plugin in a subdir and being able to pass arguments to `luarocks` helps me to not do wonky things in order to use this GH action:
https://github.com/hudson-trading/slang-server/pull/204/files
```yml
        with:
          luarocks_args: 'clients/neovim/slang-server.nvim-scm-1.rockspec --test-type busted -- -C clients/neovim/'
```

(I'm aware that having the plugin in a subdir isn't very neovim plugin canonical)

But in general, it seems handy to allow the user to pass arguments through.